### PR TITLE
Move coveralls rebar configuration to script

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,6 +6,3 @@
         ]}
     ]}
 ]}.
-{cover_export_enabled, true}.
-{coveralls_coverdata, "_build/test/cover/*.coverdata"}.
-{coveralls_service_name, "travis-ci"}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,1 @@
 {deps, []}.
-{profiles, [
-    {test, [
-        {plugins, [
-            coveralls
-        ]}
-    ]}
-]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -5,7 +5,19 @@ case os:getenv("TRAVIS") of
     CONFIG2 = lists:keystore(coveralls_service_name, 1, CONFIG1, {coveralls_service_name, "travis-ci"}),
     CONFIG3 = lists:keystore(coveralls_coverdata, 1, CONFIG2, {coveralls_coverdata, "_build/test/cover/*.coverdata"}),
     CONFIG4 = lists:keystore(cover_export_enabled, 1, CONFIG3, {cover_export_enabled, true}),
-    CONFIG4;
+    PROFILES1 = proplists:get_value(profiles, CONFIG4, []),
+    TEST_PROFILE_CONFIG1 = proplists:get_value(test, PROFILES1, []),
+    TEST_PLUGINS1 = proplists:get_value(plugins, TEST_PROFILE_CONFIG1, []),
+    TEST_PLUGINS2 =
+        case lists:member(coveralls, TEST_PLUGINS1) or lists:keymember(coveralls, 1, TEST_PLUGINS1) of
+            true ->
+                TEST_PLUGINS1;
+            false ->
+                TEST_PLUGINS1 ++ [coveralls]
+        end,
+    TEST_PROFILE_CONFIG2 = lists:keystore(plugins, 1, TEST_PROFILE_CONFIG1, {plugins, TEST_PLUGINS2}),
+    PROFILES2 = lists:keystore(test, 1, PROFILES1, {test, TEST_PROFILE_CONFIG2}),
+    lists:keystore(profiles, 1, CONFIG4, {profiles, PROFILES2});
   _ ->
     CONFIG
 end.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,7 +1,11 @@
 case os:getenv("TRAVIS") of
   "true" ->
     JobId   = os:getenv("TRAVIS_JOB_ID"),
-    lists:keystore(coveralls_service_job_id, 1, CONFIG, {coveralls_service_job_id, JobId});
+    CONFIG1 = lists:keystore(coveralls_service_job_id, 1, CONFIG, {coveralls_service_job_id, JobId}),
+    CONFIG2 = lists:keystore(coveralls_service_name, 1, CONFIG1, {coveralls_service_name, "travis-ci"}),
+    CONFIG3 = lists:keystore(coveralls_coverdata, 1, CONFIG2, {coveralls_coverdata, "_build/test/cover/*.coverdata"}),
+    CONFIG4 = lists:keystore(cover_export_enabled, 1, CONFIG3, {cover_export_enabled, true}),
+    CONFIG4;
   _ ->
     CONFIG
 end.


### PR DESCRIPTION
Rationale is that anyone who downloads repository can run compilation and all tests etc. but running `coveralls` is specific to Travis only. 